### PR TITLE
Allow consumer to disable scroll on new tab

### DIFF
--- a/src/Input/ComponentSelector.svelte
+++ b/src/Input/ComponentSelector.svelte
@@ -2,8 +2,11 @@
 	import { getContext, createEventDispatcher } from 'svelte';
 
 	export let handle_select;
+	export let scrollOnNewTab;
 
 	const { components, selected, request_focus, rebundle } = getContext('REPL');
+
+	const ROOT_CLASS_NAME = 'component-selector';
 
 	let editing = null;
 
@@ -61,7 +64,7 @@
 
 	let uid = 1;
 
-	function addNew() {
+	function addNew(event) {
 		const component = {
 			name: uid++ ? `Component${uid}` : 'Component1',
 			type: 'svelte',
@@ -70,10 +73,13 @@
 
 		editing = component;
 
-		setTimeout(() => {
-			// TODO we can do this without IDs
-			document.getElementById(component.name).scrollIntoView(false);
-		});
+		if (scrollOnNewTab) {
+			setTimeout(() => {
+				const currentComponentSelector = event.target.closest(`.${ROOT_CLASS_NAME}`);
+
+				currentComponentSelector.scrollIntoView();
+			});
+		}
 
 		components.update(components => components.concat(component));
 		handle_select(component);
@@ -196,7 +202,7 @@
 	}
 </style>
 
-<div class="component-selector">
+<div class={ROOT_CLASS_NAME}>
 	{#if $components.length}
 		<div class="file-tabs" on:dblclick="{addNew}">
 			{#each $components as component}

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -18,6 +18,7 @@
 	export let fixedPos = 50;
 	export let injectedJS = '';
 	export let injectedCSS = '';
+	export let scrollOnNewTab = true;
 
 	export function toJSON() {
 		// TODO there's a bug here — Svelte hoists this function because
@@ -211,7 +212,7 @@
 		{fixed}
 	>
 		<section slot=a>
-			<ComponentSelector {handle_select}/>
+			<ComponentSelector {handle_select} {scrollOnNewTab}/>
 			<ModuleEditor bind:this={input} errorLoc="{sourceErrorLoc || runtimeErrorLoc}"/>
 		</section>
 


### PR DESCRIPTION
Based on issue #9 
This implements the ability to change the current behavior when you add a new tab.

In order to keep the current behavior, which is to scroll when a new tab is added, the default for the `scrollOnNewTab` is true -- but in this case, the element will scroll to the top of the page instead of the bottom, like before. This seems more reasonable since the text area is located below the tab selector area.

ps: indentation for svelte files looks pretty weird in Github 🤔 