### PR TITLE
Add overflow: auto to Compiler options section

### DIFF
--- a/src/Output/index.svelte
+++ b/src/Output/index.svelte
@@ -87,6 +87,10 @@
 		height: 100%;
 	}
 
+	section[slot] {
+		overflow: auto;
+	}
+
 	h3 {
 		font: 700 12px/1.5 var(--font);
 		padding: 12px 0 8px 10px;


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/2515

Changes the Compiler options section from this:
![compiler-options-1](https://user-images.githubusercontent.com/11573167/57625465-2ea9cb80-7594-11e9-9f8d-033d6b844203.gif)

To this:
![compiler-options-2](https://user-images.githubusercontent.com/11573167/57625467-30738f00-7594-11e9-85fe-6930ef3ff407.gif)