### PR TITLE
Feature autoclose tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sveltejs/svelte-repl",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -544,9 +544,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -157,7 +157,8 @@
 			mode: modes[mode] || {
 				name: mode
 			},
-			readOnly: readonly
+			readOnly: readonly,
+			autoCloseTags: true
 		};
 
 		if (!tab) opts.extraKeys = {

--- a/src/codemirror.js
+++ b/src/codemirror.js
@@ -7,5 +7,6 @@ import 'codemirror/mode/handlebars/handlebars.js';
 import 'codemirror/mode/htmlmixed/htmlmixed.js';
 import 'codemirror/mode/xml/xml.js';
 import 'codemirror/mode/css/css.js';
+import 'codemirror/addon/edit/closetag.js';
 
 export default CodeMirror;


### PR DESCRIPTION
This adds the closetags option to the Codemirror component, which resolves this issue: https://github.com/sveltejs/svelte-repl/issues/14

I confess that because I haven't been able to run this REPL locally, I have no proof that this works, but I would be surprised (and disappointed) if it didn't.

I would be very grateful if someone who could run it locally could either tell me how to, or check if this works.