### PR TITLE
Feature autoclose brackets

### DIFF
--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -157,7 +157,8 @@
 			mode: modes[mode] || {
 				name: mode
 			},
-			readOnly: readonly
+			readOnly: readonly,
+			autoCloseBrackets: true
 		};
 
 		if (!tab) opts.extraKeys = {

--- a/src/codemirror.js
+++ b/src/codemirror.js
@@ -7,5 +7,6 @@ import 'codemirror/mode/handlebars/handlebars.js';
 import 'codemirror/mode/htmlmixed/htmlmixed.js';
 import 'codemirror/mode/xml/xml.js';
 import 'codemirror/mode/css/css.js';
+import 'codemirror/addon/edit/closebrackets.js';
 
 export default CodeMirror;


### PR DESCRIPTION
This adds the autoclose brackets option to the CodeMirror component, which resolves issue https://github.com/sveltejs/svelte-repl/issues/16 

As I mentioned [here](https://github.com/sveltejs/svelte-repl/pull/17), I can't run this locally to check it works. I apologise for that. That being said, I expect the maintainers could check very easily.