### PR TITLE
use svelte.VERSION to sniff version, not svelteUrl

### DIFF
--- a/src/workers/bundler/index.js
+++ b/src/workers/bundler/index.js
@@ -96,13 +96,10 @@ async function get_bundle(uid, mode, cache, lookup) {
 			// importing from Svelte
 			if (importee === `svelte`) return `${svelteUrl}/index.mjs`;
 			if (importee.startsWith(`svelte/`)) {
-				const m = svelteUrl.match(/@3\.(\d+)\.(\d+)$/);
-				if (m) {
-					if (+m[1] < 4 || +m[1] === 4 && +m[2] <= 4) {
-						return `${svelteUrl}/${importee.slice(7)}.mjs`;
-					}
-				}
-				return `${svelteUrl}/${importee.slice(7)}/index.mjs`;
+				const [, major, minor, patch] = svelte.VERSION.match(/^(\d+)\.(\d+)\.(\d+)/);
+				return (major - 3) || (minor - 4) || (patch - 4) <= 0 ?
+					`${svelteUrl}/${importee.slice(7)}.mjs` :
+					`${svelteUrl}/${importee.slice(7)}/index.mjs`;
 			}
 
 			// temporary workaround for lack of package.json files in sub-packages


### PR DESCRIPTION
Resolves #22 hopefully for real.