### PR TITLE
scope status messages to uid

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -17,14 +17,14 @@ export default class Bundler {
 		this.handlers = new Map();
 
 		this.worker.addEventListener('message', event => {
-			if (event.data.type === 'status') {
-				onstatus(event.data.message);
-				return;
-			}
-
 			const handler = this.handlers.get(event.data.uid);
 
 			if (handler) { // if no handler, was meant for a different REPL
+				if (event.data.type === 'status') {
+					onstatus(event.data.message);
+					return;
+				}
+
 				onstatus(null);
 				handler(event.data);
 				this.handlers.delete(event.data.uid);

--- a/src/workers/bundler/index.js
+++ b/src/workers/bundler/index.js
@@ -124,14 +124,14 @@ async function get_bundle(uid, mode, cache, lookup) {
 			// importing from (probably) unpkg
 			if (importee.startsWith('.')) {
 				const url = new URL(importee, importer).href;
-				self.postMessage({ type: 'status', message: `resolving ${url}` });
+				self.postMessage({ type: 'status', uid, message: `resolving ${url}` });
 
 				return await follow_redirects(url);
 			}
 
 			else {
 				// fetch from unpkg
-				self.postMessage({ type: 'status', message: `resolving ${importee}` });
+				self.postMessage({ type: 'status', uid, message: `resolving ${importee}` });
 
 				if (importer in lookup) {
 					const match = /^(@[^/]+\/)?[^/]+/.exec(importee);
@@ -160,7 +160,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 			if (resolved in lookup) return lookup[resolved].source;
 
 			if (!fetch_cache.has(resolved)) {
-				self.postMessage({ type: 'status', message: `fetching ${resolved}` });
+				self.postMessage({ type: 'status', uid, message: `fetching ${resolved}` });
 			}
 
 			const res = await fetch_if_uncached(resolved);
@@ -169,7 +169,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 		transform(code, id) {
 			if (uid !== current_id) throw ABORT;
 
-			self.postMessage({ type: 'status', message: `bundling ${id}` });
+			self.postMessage({ type: 'status', uid, message: `bundling ${id}` });
 
 			if (!/\.svelte$/.test(id)) return null;
 


### PR DESCRIPTION
Fixes #31. This includes `uid` in each `status` update message from the worker, and piggybacks on the `handlers` map in the bundlers to see whether this message was intended for us, but does not actually use the handler if it is a `status` message.