### PR TITLE
fix: warnings scrolling issue

### DIFF
--- a/src/Input/ModuleEditor.svelte
+++ b/src/Input/ModuleEditor.svelte
@@ -30,6 +30,12 @@
 		flex: 1 1 auto;
 	}
 
+	.info {
+		background-color: var(--second);
+		max-height: 50%;
+		overflow: scroll;
+	}
+
 	:global(.columns) .editor-wrapper {
 		/* make it easier to interact with scrollbar */
 		padding-right: 8px;

--- a/src/Message.svelte
+++ b/src/Message.svelte
@@ -66,10 +66,6 @@
 		margin: 0;
 	}
 
-	.info {
-		background-color: var(--second);
-	}
-
 	.error {
 		background-color: #da106e;
 	}


### PR DESCRIPTION
Fix #47

Added a max-height + overflow scroll to warnings container

<img width="1280" alt="Screenshot 2019-11-10 at 5 48 53 PM" src="https://user-images.githubusercontent.com/2338632/68542034-64642b80-03e2-11ea-9434-a41754107edf.png">
