### PR TITLE
use loopGuardTimeout

### DIFF
--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -5,7 +5,7 @@
 	let _CodeMirror;
 
 	if (is_browser) {
-		codemirror_promise = import(/* webpackChunkName: "codemirror" */ './codemirror.js');
+		codemirror_promise = import('./codemirror.js');
 
 		codemirror_promise.then(mod => {
 			_CodeMirror = mod.default;
@@ -14,11 +14,10 @@
 </script>
 
 <script>
-	import { onMount, beforeUpdate, createEventDispatcher, getContext } from 'svelte';
+	import { onMount, createEventDispatcher } from 'svelte';
 	import Message from './Message.svelte';
 
 	const dispatch = createEventDispatcher();
-	const { navigate } = getContext('REPL');
 
 	export let readonly = false;
 	export let errorLoc = null;

--- a/src/Input/ComponentSelector.svelte
+++ b/src/Input/ComponentSelector.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { getContext, createEventDispatcher } from 'svelte';
+	import { getContext } from 'svelte';
 
 	export let handle_select;
 

--- a/src/Input/ModuleEditor.svelte
+++ b/src/Input/ModuleEditor.svelte
@@ -3,7 +3,7 @@
 	import CodeMirror from '../CodeMirror.svelte';
 	import Message from '../Message.svelte';
 
-	const { bundle, selected, handle_change, navigate, register_module_editor } = getContext('REPL');
+	const { bundle, selected, handle_change, register_module_editor } = getContext('REPL');
 
 	export let errorLoc;
 

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -1,13 +1,11 @@
 <script>
-	import { onMount, createEventDispatcher, getContext } from 'svelte';
+	import { onMount, getContext } from 'svelte';
 	import getLocationFromStack from './getLocationFromStack.js';
 	import ReplProxy from './ReplProxy.js';
 	import Message from '../Message.svelte';
 	import srcdoc from './srcdoc/index.js';
-	import { decode } from 'sourcemap-codec';
 
-	const dispatch = createEventDispatcher();
-	const { bundle, navigate } = getContext('REPL');
+	const { bundle } = getContext('REPL');
 
 	export let error; // TODO should this be exposed as a prop?
 

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -1,8 +1,7 @@
 <script>
-	import { onMount, setContext, createEventDispatcher } from 'svelte';
+	import { setContext, createEventDispatcher } from 'svelte';
 	import { writable } from 'svelte/store';
 	import SplitPane from './SplitPane.svelte';
-	import CodeMirror from './CodeMirror.svelte';
 	import ComponentSelector from './Input/ComponentSelector.svelte';
 	import ModuleEditor from './Input/ModuleEditor.svelte';
 	import Output from './Output/index.svelte';
@@ -21,12 +20,6 @@
 	export let injectedCSS = '';
 
 	export function toJSON() {
-		// TODO there's a bug here — Svelte hoists this function because
-		// it wrongly things that $components is global. Needs to
-		// factor in $ variables when determining hoistability
-
-		svelteUrl; // workaround
-
 		return {
 			imports: $bundle.imports,
 			components: $components


### PR DESCRIPTION
Fixes #40 (which apparently was autoclosed when the feature merely became available in Svelte).

This adds another version sniff for >= 3.14.0, which is when loopGuardTimeout was added.

Also included are some various unrelated deletions of unused code that I had laying around in my local tree.