### PR TITLE
fix duplicated component name tab

### DIFF
--- a/src/Input/ComponentSelector.svelte
+++ b/src/Input/ComponentSelector.svelte
@@ -23,7 +23,12 @@
 	function closeEdit() {
 		const match = /(.+)\.(svelte|js)$/.exec($selected.name);
 		$selected.name = match ? match[1] : $selected.name;
+		if (isComponentNameUsed($selected)) {
+			$selected.name = $selected.name + '_1';
+		}
 		if (match && match[2]) $selected.type = match[2];
+
+
 		editing = null;
 
 		// re-select, in case the type changed
@@ -77,6 +82,10 @@
 
 		components.update(components => components.concat(component));
 		handle_select(component);
+	}
+
+	function isComponentNameUsed(editing) {
+		return $components.find(component => component !== editing && component.name === editing.name);
 	}
 </script>
 
@@ -141,6 +150,10 @@
 		background-color: transparent;
 	}
 
+	.duplicate {
+		color: var(--prime);
+	}
+
 	.remove {
 		position: absolute;
 		display: none;
@@ -199,7 +212,7 @@
 <div class="component-selector">
 	{#if $components.length}
 		<div class="file-tabs" on:dblclick="{addNew}">
-			{#each $components as component}
+			{#each $components as component, index}
 				<div
 					id={component.name}
 					class="button"
@@ -208,7 +221,7 @@
 					on:click="{() => selectComponent(component)}"
 					on:dblclick="{e => e.stopPropagation()}"
 				>
-					{#if component.name == 'App'}
+					{#if component.name == 'App' && index === 0}
 						<div class="uneditable">
 							App.svelte
 						</div>
@@ -223,7 +236,8 @@
 								bind:value={editing.name}
 								on:focus={selectInput}
 								on:blur={closeEdit}
-								on:keydown={e => e.which === 13 && e.target.blur()}
+								on:keydown={e => e.which === 13 && !isComponentNameUsed(editing) && e.target.blur()}
+								class:duplicate={isComponentNameUsed(editing)}
 							>
 						{:else}
 							<div


### PR DESCRIPTION
- Fix when typing "App" will automatically become uneditable https://github.com/sveltejs/svelte-repl/issues/36
<img width="233" alt="Screenshot 2019-11-14 at 8 03 44 AM" src="https://user-images.githubusercontent.com/2338632/68815179-af699180-06b5-11ea-8301-70c1ac467052.png">

- Fix to disallow duplicate component names
  - turn the input text color to red
  - disable on enter key
  - on input blur, will try to append a suffix to prevent name duplication

<img width="370" alt="Screenshot 2019-11-14 at 8 03 56 AM" src="https://user-images.githubusercontent.com/2338632/68815235-d6c05e80-06b5-11ea-90a8-98eeedc1129e.png">

<img width="372" alt="Screenshot 2019-11-14 at 8 04 00 AM" src="https://user-images.githubusercontent.com/2338632/68815258-eb045b80-06b5-11ea-978a-ec75c8c5d8e9.png">

