### PR TITLE
Add console panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,6 +1083,11 @@
       "integrity": "sha512-7gMPjARR9D797MSVaiUkILVfqDaDLKRQAPTGK5kktSmrPWE0iuHRTKIdhpMOa/MSQBM94NMUv8owR4LXrhrgfQ==",
       "dev": true
     },
+    "svelte-json-tree": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/svelte-json-tree/-/svelte-json-tree-0.0.5.tgz",
+      "integrity": "sha512-kTcOVlsldI2neszYNQAfFCt+u62OWWAZgpeoW9RN3hjtJCWI5bkVj0gtljZWUlyEWTfgpmag5L5AHDKg8w8ZmQ=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "codemirror": "^5.49.2",
     "estree-walker": "^0.9.0",
     "sourcemap-codec": "^1.4.6",
+    "svelte-json-tree": "0.0.5",
     "yootils": "0.0.16"
   }
 }

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,0 +1,16 @@
+<script>
+  export let logs;
+</script>
+<style>
+  .logs {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+</style>
+
+<div class="logs">
+  {#each logs as log}
+    <div class={`console-${log.level}`}>{log.args}</div>
+  {/each}
+</div>

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,16 +1,100 @@
 <script>
+  import JSONNode from 'svelte-json-tree';
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
   export let logs;
+
+  $: logs_length = logs.filter(log => log.level !== 'announcement').length
+
+  function toggleExpand() {
+    dispatch('toggle');
+  }
+  function clear(event) {
+    event.stopPropagation();
+    dispatch('clear');
+  }
 </script>
 <style>
   .logs {
+    height: calc(100% - 42px);
+    overflow: auto;
+  }
+  .container {
     position: absolute;
     bottom: 0;
     width: 100%;
   }
+  .header {
+    height: 42px;
+    color: #333;
+    background: var(--back);
+    border-top: 1px solid var(--second);
+    border-bottom: 1px solid var(--second);
+    font: 400 12px/1.5 var(--font);
+    padding: 12px 12px 8px 12px;
+    cursor: pointer;
+  }
+  .pill {
+    background: var(--prime);
+    color: white;
+    border-radius: 50%;
+    padding: 2px 4px;
+    font-size: 0.8em;
+    min-width: 18px;
+    display: inline-block;
+    text-align: center;
+  }
+  .log {
+    border-bottom: 1px solid #eee;
+    padding: 5px 10px;
+    display: flex;
+  }
+  .log > :global(*) {
+    margin-right: 10px;
+  }
+  .console-warn {
+    background: #fffbe6;
+    border-color: #fff4c4;
+  }
+  .console-error {
+    background: #fff0f0;
+    border-color: #fed6d7;
+  }
+  .console-announcement {
+    background: #fffbe6;
+    border-color: #fff4c4;
+    color: #735828;
+    font-size: 13px;
+  }
+  button {
+    float: right;
+    color: #999;
+  }
+  button:hover {
+    color: #333;
+  }
 </style>
-
-<div class="logs">
-  {#each logs as log}
-    <div class={`console-${log.level}`}>{log.args}</div>
-  {/each}
+<div class="container">
+  <div class="header" on:click={toggleExpand}>
+    Console 
+    {#if logs_length > 0}
+      <span class="pill">{logs_length}</span>
+    {/if}
+    <button on:click={clear}>Clear</button>
+  </div>
+  <div class="logs">
+    {#each logs as log}
+      <div class={`log console-${log.level}`}>
+        {#if log.level === 'announcement'}
+          {log.message}
+        {:else}
+          {#each log.args as arg}
+            <JSONNode value={arg} />
+          {/each}
+        {/if}
+      </div>
+    {/each}
+  </div>
 </div>

--- a/src/Output/ReplProxy.js
+++ b/src/Output/ReplProxy.js
@@ -52,12 +52,16 @@ export default class ReplProxy {
 
 		const { action, args } = event.data;
 
-		if (action === 'cmd_error' || action === 'cmd_ok') {
-			this.handle_command_message(event.data);
-		}
-
-		if (action === 'fetch_progress') {
-			this.handlers.on_fetch_progress(args.remaining)
+		switch (action) {
+			case 'cmd_error':
+			case 'cmd_ok':
+				return this.handle_command_message(event.data);
+			case 'fetch_progress':
+				return this.handlers.on_fetch_progress(args.remaining)
+			case 'error':
+				return this.handlers.on_error(event.data);
+			case 'unhandledrejection':
+				return this.handlers.on_unhandled_rejection(event.data);
 		}
 	}
 

--- a/src/Output/ReplProxy.js
+++ b/src/Output/ReplProxy.js
@@ -62,6 +62,8 @@ export default class ReplProxy {
 				return this.handlers.on_error(event.data);
 			case 'unhandledrejection':
 				return this.handlers.on_unhandled_rejection(event.data);
+			case 'console':
+				return this.handlers.on_console(event.data);
 		}
 	}
 

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -2,12 +2,14 @@
 	import { onMount, getContext } from 'svelte';
 	import getLocationFromStack from './getLocationFromStack.js';
 	import ReplProxy from './ReplProxy.js';
+	import Console from './Console.svelte';
 	import Message from '../Message.svelte';
 	import srcdoc from './srcdoc/index.js';
 
 	const { bundle } = getContext('REPL');
 
 	export let error; // TODO should this be exposed as a prop?
+	let logs = [];
 
 	export function setProp(prop, value) {
 		if (!proxy) return;
@@ -41,6 +43,9 @@
 				if (typeof error === 'string') error = { message: error };
 				error.message = 'Uncaught (in promise): ' + error.message;
 				show_error(error);
+			},
+			on_console: event => {
+				logs = [...logs, event];
 			}
 		});
 
@@ -89,6 +94,7 @@
 			`);
 
 			error = null;
+			logs = [];
 		} catch (e) {
 			show_error(e);
 		}
@@ -161,4 +167,5 @@
 			<Message kind="info" truncate>{status || 'loading Svelte compiler...'}</Message>
 		{/if}
 	</div>
+	<Console {logs} />
 </div>

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -68,6 +68,14 @@
 					parent.postMessage({ action: 'unhandledrejection', value: event.reason }, '*');
 				});
 			}).call(this);
+
+			['log', 'warn', 'error'].forEach((level) => {
+				const original = console[level];
+				console[level] = (...args) => {
+					parent.postMessage({ action: 'console', level, args }, '*');
+					original(...args);
+				}
+			})
 		</script>
 	</head>
 	<body></body>

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -59,6 +59,14 @@
 				}
 
 				window.addEventListener('message', handle_message, false);
+
+				window.onerror = function (msg, url, lineNo, columnNo, error) {
+					parent.postMessage({ action: 'error', value: error }, '*');
+				}
+
+				window.addEventListener("unhandledrejection", event => {
+					parent.postMessage({ action: 'unhandledrejection', value: event.reason }, '*');
+				});
 			}).call(this);
 		</script>
 	</head>


### PR DESCRIPTION
<img width="1280" alt="Screenshot 2019-11-17 at 12 36 07 AM" src="https://user-images.githubusercontent.com/2338632/68996269-9ee23280-08d2-11ea-9fac-e13640d8a35b.png">

- intercepts all logs from iframe and show in the console panel
- uses [svelte-json-tree](https://www.npmjs.com/package/svelte-json-tree) to display json object
- errors and uncaughtrejection will be shown in console panel

Fix: https://github.com/sveltejs/svelte-repl/issues/51