### PR TITLE
More console panel stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,6 +1083,11 @@
       "integrity": "sha512-7gMPjARR9D797MSVaiUkILVfqDaDLKRQAPTGK5kktSmrPWE0iuHRTKIdhpMOa/MSQBM94NMUv8owR4LXrhrgfQ==",
       "dev": true
     },
+    "svelte-json-tree": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/svelte-json-tree/-/svelte-json-tree-0.0.5.tgz",
+      "integrity": "sha512-kTcOVlsldI2neszYNQAfFCt+u62OWWAZgpeoW9RN3hjtJCWI5bkVj0gtljZWUlyEWTfgpmag5L5AHDKg8w8ZmQ=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "codemirror": "^5.49.2",
     "estree-walker": "^0.9.0",
     "sourcemap-codec": "^1.4.6",
+    "svelte-json-tree": "0.0.5",
     "yootils": "0.0.16"
   }
 }

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -7,6 +7,10 @@
 <div class="container">
 	{#each logs as log}
 		<div class="log console-{log.level}">
+			{#if log.count > 1}
+				<span class="count">{log.count}x</span>
+			{/if}
+
 			{#if log.level === 'clear'}
 				<span class="info">Console was cleared</span>
 			{:else if log.level === 'unclonable'}
@@ -40,6 +44,12 @@
 	.console-error {
 		background: #fff0f0;
 		border-color: #fed6d7;
+	}
+
+	.count {
+		color: #999;
+		font-size: 12px;
+		line-height: 1.2;
 	}
 
 	.info {

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -7,9 +7,15 @@
 <div class="container">
 	{#each logs as log}
 		<div class="log console-{log.level}">
-			{#each log.args as arg}
-				<JSONNode value={arg} />
-			{/each}
+			{#if log.level === 'clear'}
+				<span class="info">Console was cleared</span>
+			{:else if log.level === 'unclonable'}
+				<span class="info error">Message could not be cloned. Open devtools to see it</span>
+			{:else}
+				{#each log.args as arg}
+					<JSONNode value={arg} />
+				{/each}
+			{/if}
 		</div>
 	{/each}
 </div>
@@ -34,5 +40,15 @@
 	.console-error {
 		background: #fff0f0;
 		border-color: #fed6d7;
+	}
+
+	.info {
+		color: #666;
+		font-family: var(--font) !important;
+		font-size: 12px;
+	}
+
+	.error {
+		color: #da106e; /* todo make this a var */
 	}
 </style>

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -6,8 +6,6 @@
 
   export let logs;
 
-  $: logs_length = logs.filter(log => log.level !== 'announcement').length
-
   function toggleExpand() {
     dispatch('toggle');
   }
@@ -62,12 +60,6 @@
     background: #fff0f0;
     border-color: #fed6d7;
   }
-  .console-announcement {
-    background: #fffbe6;
-    border-color: #fff4c4;
-    color: #735828;
-    font-size: 13px;
-  }
   button {
     float: right;
     color: #999;
@@ -78,22 +70,18 @@
 </style>
 <div class="container">
   <div class="header" on:click={toggleExpand}>
-    Console 
-    {#if logs_length > 0}
-      <span class="pill">{logs_length}</span>
+    Console
+    {#if logs.length > 0}
+      <span class="pill">{logs.length}</span>
     {/if}
     <button on:click={clear}>Clear</button>
   </div>
   <div class="logs">
     {#each logs as log}
       <div class={`log console-${log.level}`}>
-        {#if log.level === 'announcement'}
-          {log.message}
-        {:else}
-          {#each log.args as arg}
-            <JSONNode value={arg} />
-          {/each}
-        {/if}
+        {#each log.args as arg}
+          <JSONNode value={arg} />
+        {/each}
       </div>
     {/each}
   </div>

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,0 +1,16 @@
+<script>
+  export let logs;
+</script>
+<style>
+  .logs {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+</style>
+
+<div class="logs">
+  {#each logs as log}
+    <div class={`console-${log.level}`}>{log.args}</div>
+  {/each}
+</div>

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -23,6 +23,7 @@
 
 	.log > :global(*) {
 		margin-right: 10px;
+		font-family: var(--font-mono);
 	}
 
 	.console-warn {

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,88 +1,37 @@
 <script>
 	import JSONNode from 'svelte-json-tree';
-	import { createEventDispatcher } from 'svelte';
-
-	const dispatch = createEventDispatcher();
 
 	export let logs;
-
-	function toggleExpand() {
-		dispatch('toggle');
-	}
-	function clear(event) {
-		event.stopPropagation();
-		dispatch('clear');
-	}
 </script>
+
+<div class="container">
+	{#each logs as log}
+		<div class="log console-{log.level}">
+			{#each log.args as arg}
+				<JSONNode value={arg} />
+			{/each}
+		</div>
+	{/each}
+</div>
+
 <style>
-	.logs {
-		height: calc(100% - 42px);
-		overflow: auto;
-	}
-	.container {
-		position: absolute;
-		bottom: 0;
-		width: 100%;
-	}
-	.header {
-		height: 42px;
-		color: #333;
-		background: var(--back);
-		border-top: 1px solid var(--second);
-		border-bottom: 1px solid var(--second);
-		font: 400 12px/1.5 var(--font);
-		padding: 12px 12px 8px 12px;
-		cursor: pointer;
-	}
-	.pill {
-		background: var(--prime);
-		color: white;
-		border-radius: 50%;
-		padding: 2px 4px;
-		font-size: 0.8em;
-		min-width: 18px;
-		display: inline-block;
-		text-align: center;
-	}
 	.log {
 		border-bottom: 1px solid #eee;
 		padding: 5px 10px;
 		display: flex;
 	}
+
 	.log > :global(*) {
 		margin-right: 10px;
 	}
+
 	.console-warn {
 		background: #fffbe6;
 		border-color: #fff4c4;
 	}
+
 	.console-error {
 		background: #fff0f0;
 		border-color: #fed6d7;
 	}
-	button {
-		float: right;
-		color: #999;
-	}
-	button:hover {
-		color: #333;
-	}
 </style>
-<div class="container">
-	<div class="header" on:click={toggleExpand}>
-		Console
-		{#if logs.length > 0}
-			<span class="pill">{logs.length}</span>
-		{/if}
-		<button on:click={clear}>Clear</button>
-	</div>
-	<div class="logs">
-		{#each logs as log}
-			<div class={`log console-${log.level}`}>
-				{#each log.args as arg}
-					<JSONNode value={arg} />
-				{/each}
-			</div>
-		{/each}
-	</div>
-</div>

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,16 +1,100 @@
 <script>
+  import JSONNode from 'svelte-json-tree';
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
   export let logs;
+
+  $: logs_length = logs.filter(log => log.level !== 'announcement').length
+
+  function toggleExpand() {
+    dispatch('toggle');
+  }
+  function clear(event) {
+    event.stopPropagation();
+    dispatch('clear');
+  }
 </script>
 <style>
   .logs {
+    height: calc(100% - 42px);
+    overflow: auto;
+  }
+  .container {
     position: absolute;
     bottom: 0;
     width: 100%;
   }
+  .header {
+    height: 42px;
+    color: #333;
+    background: var(--back);
+    border-top: 1px solid var(--second);
+    border-bottom: 1px solid var(--second);
+    font: 400 12px/1.5 var(--font);
+    padding: 12px 12px 8px 12px;
+    cursor: pointer;
+  }
+  .pill {
+    background: var(--prime);
+    color: white;
+    border-radius: 50%;
+    padding: 2px 4px;
+    font-size: 0.8em;
+    min-width: 18px;
+    display: inline-block;
+    text-align: center;
+  }
+  .log {
+    border-bottom: 1px solid #eee;
+    padding: 5px 10px;
+    display: flex;
+  }
+  .log > :global(*) {
+    margin-right: 10px;
+  }
+  .console-warn {
+    background: #fffbe6;
+    border-color: #fff4c4;
+  }
+  .console-error {
+    background: #fff0f0;
+    border-color: #fed6d7;
+  }
+  .console-announcement {
+    background: #fffbe6;
+    border-color: #fff4c4;
+    color: #735828;
+    font-size: 13px;
+  }
+  button {
+    float: right;
+    color: #999;
+  }
+  button:hover {
+    color: #333;
+  }
 </style>
-
-<div class="logs">
-  {#each logs as log}
-    <div class={`console-${log.level}`}>{log.args}</div>
-  {/each}
+<div class="container">
+  <div class="header" on:click={toggleExpand}>
+    Console 
+    {#if logs_length > 0}
+      <span class="pill">{logs_length}</span>
+    {/if}
+    <button on:click={clear}>Clear</button>
+  </div>
+  <div class="logs">
+    {#each logs as log}
+      <div class={`log console-${log.level}`}>
+        {#if log.level === 'announcement'}
+          {log.message}
+        {:else}
+          {#each log.args as arg}
+            <JSONNode value={arg} />
+          {/each}
+        {/if}
+      </div>
+    {/each}
+  </div>
 </div>

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,88 +1,88 @@
 <script>
-  import JSONNode from 'svelte-json-tree';
-  import { createEventDispatcher } from 'svelte';
+	import JSONNode from 'svelte-json-tree';
+	import { createEventDispatcher } from 'svelte';
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  export let logs;
+	export let logs;
 
-  function toggleExpand() {
-    dispatch('toggle');
-  }
-  function clear(event) {
-    event.stopPropagation();
-    dispatch('clear');
-  }
+	function toggleExpand() {
+		dispatch('toggle');
+	}
+	function clear(event) {
+		event.stopPropagation();
+		dispatch('clear');
+	}
 </script>
 <style>
-  .logs {
-    height: calc(100% - 42px);
-    overflow: auto;
-  }
-  .container {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-  }
-  .header {
-    height: 42px;
-    color: #333;
-    background: var(--back);
-    border-top: 1px solid var(--second);
-    border-bottom: 1px solid var(--second);
-    font: 400 12px/1.5 var(--font);
-    padding: 12px 12px 8px 12px;
-    cursor: pointer;
-  }
-  .pill {
-    background: var(--prime);
-    color: white;
-    border-radius: 50%;
-    padding: 2px 4px;
-    font-size: 0.8em;
-    min-width: 18px;
-    display: inline-block;
-    text-align: center;
-  }
-  .log {
-    border-bottom: 1px solid #eee;
-    padding: 5px 10px;
-    display: flex;
-  }
-  .log > :global(*) {
-    margin-right: 10px;
-  }
-  .console-warn {
-    background: #fffbe6;
-    border-color: #fff4c4;
-  }
-  .console-error {
-    background: #fff0f0;
-    border-color: #fed6d7;
-  }
-  button {
-    float: right;
-    color: #999;
-  }
-  button:hover {
-    color: #333;
-  }
+	.logs {
+		height: calc(100% - 42px);
+		overflow: auto;
+	}
+	.container {
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+	}
+	.header {
+		height: 42px;
+		color: #333;
+		background: var(--back);
+		border-top: 1px solid var(--second);
+		border-bottom: 1px solid var(--second);
+		font: 400 12px/1.5 var(--font);
+		padding: 12px 12px 8px 12px;
+		cursor: pointer;
+	}
+	.pill {
+		background: var(--prime);
+		color: white;
+		border-radius: 50%;
+		padding: 2px 4px;
+		font-size: 0.8em;
+		min-width: 18px;
+		display: inline-block;
+		text-align: center;
+	}
+	.log {
+		border-bottom: 1px solid #eee;
+		padding: 5px 10px;
+		display: flex;
+	}
+	.log > :global(*) {
+		margin-right: 10px;
+	}
+	.console-warn {
+		background: #fffbe6;
+		border-color: #fff4c4;
+	}
+	.console-error {
+		background: #fff0f0;
+		border-color: #fed6d7;
+	}
+	button {
+		float: right;
+		color: #999;
+	}
+	button:hover {
+		color: #333;
+	}
 </style>
 <div class="container">
-  <div class="header" on:click={toggleExpand}>
-    Console
-    {#if logs.length > 0}
-      <span class="pill">{logs.length}</span>
-    {/if}
-    <button on:click={clear}>Clear</button>
-  </div>
-  <div class="logs">
-    {#each logs as log}
-      <div class={`log console-${log.level}`}>
-        {#each log.args as arg}
-          <JSONNode value={arg} />
-        {/each}
-      </div>
-    {/each}
-  </div>
+	<div class="header" on:click={toggleExpand}>
+		Console
+		{#if logs.length > 0}
+			<span class="pill">{logs.length}</span>
+		{/if}
+		<button on:click={clear}>Clear</button>
+	</div>
+	<div class="logs">
+		{#each logs as log}
+			<div class={`log console-${log.level}`}>
+				{#each log.args as arg}
+					<JSONNode value={arg} />
+				{/each}
+			</div>
+		{/each}
+	</div>
 </div>

--- a/src/Output/PaneWithPanel.svelte
+++ b/src/Output/PaneWithPanel.svelte
@@ -1,0 +1,64 @@
+<script>
+	import { spring } from 'svelte/motion';
+	import SplitPane from '../SplitPane.svelte';
+
+	export let panel;
+	export let pos = 50;
+	let previous_pos = pos;
+
+	let max;
+
+	// we can't bind to the spring itself, but we
+	// can still use the spring to drive `pos`
+	const driver = spring(pos);
+	$: pos = $driver;
+
+	const toggle = () => {
+		driver.set(pos, { hard: true });
+
+		if (pos > 80) {
+			driver.set(previous_pos);
+		} else {
+			previous_pos = pos;
+			driver.set(max);
+		}
+	};
+</script>
+
+<SplitPane bind:max type="vertical" bind:pos={pos}>
+	<div slot="a">
+		<slot name="main"></slot>
+	</div>
+
+	<section slot="b">
+		<div class="panel-header" on:click={toggle}>
+			<h3>{panel}</h3>
+			<slot name="panel-header"></slot>
+		</div>
+
+		<div class="panel-body">
+			<slot name="panel-body"></slot>
+		</div>
+	</section>
+</SplitPane>
+
+<style>
+	.panel-header {
+		height: 40px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0 0.5em;
+		cursor: pointer;
+	}
+
+	.panel-body {
+		max-height: 100% - 40px;
+		overflow: auto;
+	}
+
+	h3 {
+		font: 700 12px/1.5 var(--font);
+		color: #333;
+	}
+</style>

--- a/src/Output/PaneWithPanel.svelte
+++ b/src/Output/PaneWithPanel.svelte
@@ -4,7 +4,7 @@
 
 	export let panel;
 	export let pos = 50;
-	let previous_pos = pos;
+	let previous_pos = Math.min(pos, 70);
 
 	let max;
 

--- a/src/Output/ReplProxy.js
+++ b/src/Output/ReplProxy.js
@@ -52,12 +52,16 @@ export default class ReplProxy {
 
 		const { action, args } = event.data;
 
-		if (action === 'cmd_error' || action === 'cmd_ok') {
-			this.handle_command_message(event.data);
-		}
-
-		if (action === 'fetch_progress') {
-			this.handlers.on_fetch_progress(args.remaining)
+		switch (action) {
+			case 'cmd_error':
+			case 'cmd_ok':
+				return this.handle_command_message(event.data);
+			case 'fetch_progress':
+				return this.handlers.on_fetch_progress(args.remaining)
+			case 'error':
+				return this.handlers.on_error(event.data);
+			case 'unhandledrejection':
+				return this.handlers.on_unhandled_rejection(event.data);
 		}
 	}
 

--- a/src/Output/ReplProxy.js
+++ b/src/Output/ReplProxy.js
@@ -62,6 +62,8 @@ export default class ReplProxy {
 				return this.handlers.on_error(event.data);
 			case 'unhandledrejection':
 				return this.handlers.on_unhandled_rejection(event.data);
+			case 'console':
+				return this.handlers.on_console(event.data);
 		}
 	}
 

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -202,7 +202,7 @@
 </style>
 
 <div class="iframe-container">
-	<PaneWithPanel pos={60} panel="Console">
+	<PaneWithPanel pos={100} panel="Console">
 		<div slot="main">
 			<iframe
 				title="Result"

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -68,7 +68,7 @@
 		if (!$bundle || $bundle.error) return;
 
 		try {
-			push_logs({ level: 'announcement', message: 'Svelte application rebuilt!' });
+			clear_logs();
 
 			await proxy.eval(`
 				${injectedJS}
@@ -139,7 +139,7 @@
 	}
 
 	function clear_logs() {
-		logs = [{ level: 'announcement', message: 'Console was cleared' }];
+		logs = [];
 	}
 </script>
 

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -2,6 +2,7 @@
 	import { onMount, getContext } from 'svelte';
 	import getLocationFromStack from './getLocationFromStack.js';
 	import SplitPane from '../SplitPane.svelte';
+	import PaneWithPanel from './PaneWithPanel.svelte';
 	import ReplProxy from './ReplProxy.js';
 	import Console from './Console.svelte';
 	import Message from '../Message.svelte';
@@ -165,6 +166,17 @@
 		opacity: .25;
 	}
 
+	button {
+		color: #999;
+		font-size: 12px;
+		text-transform: uppercase;
+		display: block;
+	}
+
+	button:hover {
+		color: #333;
+	}
+
 	.overlay {
 		position: absolute;
 		bottom: 0;
@@ -173,8 +185,8 @@
 </style>
 
 <div class="iframe-container">
-	<SplitPane type="vertical" bind:pos={log_height}>
-		<div slot="a">
+	<PaneWithPanel pos={60} panel="Console">
+		<div slot="main">
 			<iframe
 				title="Result"
 				class:inited
@@ -185,10 +197,18 @@
 			></iframe>
 		</div>
 
-		<section slot="b">
-			<Console {logs} on:toggle={on_toggle_console} on:clear={clear_logs}/>
+		<div slot="panel-header">
+			<button on:click|stopPropagation={clear_logs}>
+				{#if (logs.length > 0)}({logs.length}){/if}
+				Clear
+			</button>
+		</div>
+
+		<section slot="panel-body">
+			<Console {logs} on:clear={clear_logs}/>
 		</section>
-	</SplitPane>
+	</PaneWithPanel>
+
 	<div class="overlay">
 		{#if error}
 			<Message kind="error" details={error}/>

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -2,12 +2,14 @@
 	import { onMount, getContext } from 'svelte';
 	import getLocationFromStack from './getLocationFromStack.js';
 	import ReplProxy from './ReplProxy.js';
+	import Console from './Console.svelte';
 	import Message from '../Message.svelte';
 	import srcdoc from './srcdoc/index.js';
 
 	const { bundle } = getContext('REPL');
 
 	export let error; // TODO should this be exposed as a prop?
+	let logs = [];
 
 	export function setProp(prop, value) {
 		if (!proxy) return;
@@ -41,6 +43,9 @@
 				if (typeof error === 'string') error = { message: error };
 				error.message = 'Uncaught (in promise): ' + error.message;
 				show_error(error);
+			},
+			on_console: event => {
+				logs = [...logs, event];
 			}
 		});
 
@@ -89,6 +94,7 @@
 			`);
 
 			error = null;
+			logs = [];
 		} catch (e) {
 			show_error(e);
 		}
@@ -161,4 +167,5 @@
 			<Message kind="info" truncate>{status || 'loading Svelte compiler...'}</Message>
 		{/if}
 	</div>
+	<Console {logs} />
 </div>

--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -50,7 +50,11 @@
 				push_logs({ level: 'error', args: [error]});
 			},
 			on_console: event => {
-				push_logs(event);
+				if (event.level === 'clear') {
+					logs = [{ level: 'clear' }];
+				} else {
+					push_logs(event);
+				}
 			}
 		});
 

--- a/src/Output/index.svelte
+++ b/src/Output/index.svelte
@@ -2,6 +2,7 @@
 	import { getContext, onMount } from 'svelte';
 	import SplitPane from '../SplitPane.svelte';
 	import Viewer from './Viewer.svelte';
+	import PaneWithPanel from './PaneWithPanel.svelte';
 	import CompilerOptions from './CompilerOptions.svelte';
 	import Compiler from './Compiler.js';
 	import CodeMirror from '../CodeMirror.svelte';
@@ -89,17 +90,6 @@
 		height: 100%;
 	}
 
-	section[slot] {
-		overflow: auto;
-	}
-
-	h3 {
-		font: 700 12px/1.5 var(--font);
-		padding: 12px 0 8px 10px;
-		/* color: var(--text); */
-		color: #333;
-	}
-
 	.tab-content {
 		position: absolute;
 		width: 100%;
@@ -154,8 +144,8 @@
 			readonly
 		/>
 	{:else}
-		<SplitPane type="vertical" pos={67}>
-			<div slot="a">
+		<PaneWithPanel pos={67} panel="Compiler options">
+			<div slot="main">
 				<CodeMirror
 					bind:this={js_editor}
 					mode="js"
@@ -164,12 +154,10 @@
 				/>
 			</div>
 
-			<section slot="b">
-				<h3>Compiler options</h3>
-
-				<CompilerOptions bind:foo={foo}/>
-			</section>
-		</SplitPane>
+			<div slot="panel-body">
+				<CompilerOptions/>
+			</div>
+		</PaneWithPanel>
 	{/if}
 </div>
 

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -68,6 +68,14 @@
 					parent.postMessage({ action: 'unhandledrejection', value: event.reason }, '*');
 				});
 			}).call(this);
+
+			['log', 'warn', 'error'].forEach((level) => {
+				const original = console[level];
+				console[level] = (...args) => {
+					parent.postMessage({ action: 'console', level, args }, '*');
+					original(...args);
+				}
+			})
 		</script>
 	</head>
 	<body></body>

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -59,6 +59,14 @@
 				}
 
 				window.addEventListener('message', handle_message, false);
+
+				window.onerror = function (msg, url, lineNo, columnNo, error) {
+					parent.postMessage({ action: 'error', value: error }, '*');
+				}
+
+				window.addEventListener("unhandledrejection", event => {
+					parent.postMessage({ action: 'unhandledrejection', value: event.reason }, '*');
+				});
 			}).call(this);
 		</script>
 	</head>

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -70,13 +70,25 @@
 			}).call(this);
 
 			// TODO handle group/groupEnd, table, trace, etc
+			let previous = { level: null, args: null };
+
 			['clear', 'log', 'info', 'dir', 'warn', 'error'].forEach((level) => {
 				const original = console[level];
 				console[level] = (...args) => {
-					try {
-						parent.postMessage({ action: 'console', level, args }, '*');
-					} catch (err) {
-						parent.postMessage({ action: 'console', level: 'unclonable' }, '*');
+					if (
+						previous.level === level &&
+						previous.args.length === args.length &&
+						previous.args.every((a, i) => a === args[i])
+					) {
+						parent.postMessage({ action: 'console', level, duplicate: true }, '*');
+					} else {
+						previous = { level, args };
+
+						try {
+							parent.postMessage({ action: 'console', level, args }, '*');
+						} catch (err) {
+							parent.postMessage({ action: 'console', level: 'unclonable' }, '*');
+						}
 					}
 
 					original(...args);

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -69,10 +69,16 @@
 				});
 			}).call(this);
 
-			['log', 'warn', 'error'].forEach((level) => {
+			// TODO handle group/groupEnd, table, trace, etc
+			['clear', 'log', 'info', 'dir', 'warn', 'error'].forEach((level) => {
 				const original = console[level];
 				console[level] = (...args) => {
-					parent.postMessage({ action: 'console', level, args }, '*');
+					try {
+						parent.postMessage({ action: 'console', level, args }, '*');
+					} catch (err) {
+						parent.postMessage({ action: 'console', level: 'unclonable' }, '*');
+					}
+
 					original(...args);
 				}
 			})

--- a/src/SplitPane.svelte
+++ b/src/SplitPane.svelte
@@ -7,27 +7,30 @@
 	export let type;
 	export let pos = 50;
 	export let fixed = false;
-	export let min = 50;
-	// export let min1 = min;
-	// export let min2 = min;
+	export let buffer = 40;
+	export let min;
+	export let max;
+
+	let w;
+	let h;
+	$: size = type === 'vertical' ? h : w;
+
+	$: min = 100 * (buffer / size);
+	$: max = 100 - min;
+	$: pos = yootils.clamp(pos, min, max);
 
 	const refs = {};
 
 	let dragging = false;
 
 	function setPos(event) {
-		const { top, bottom, left, right } = refs.container.getBoundingClientRect();
+		const { top, left } = refs.container.getBoundingClientRect();
 
-		const extents = type === 'vertical' ? [top, bottom] : [left, right];
+		const px = type === 'vertical'
+			? (event.clientY - top)
+			: (event.clientX - left);
 
-		const px = yootils.clamp(
-			type === 'vertical' ? event.clientY : event.clientX,
-			extents[0] + min,
-			extents[1] - min
-		);
-
-		pos = 100 * (px - extents[0]) / (extents[1] - extents[0]);
-
+		pos = 100 * px / size;
 		dispatch('change');
 	}
 
@@ -75,6 +78,7 @@
 		float: left;
 		width: 100%;
 		height: 100%;
+		overflow: auto;
 	}
 
 	.mousecatcher {
@@ -145,7 +149,7 @@
 	.bottom { bottom: 0; }
 </style>
 
-<div class="container" bind:this={refs.container}>
+<div class="container" bind:this={refs.container} bind:clientWidth={w} bind:clientHeight={h}>
 	<div class="pane" style="{dimension}: {pos}%;">
 		<slot name="a"></slot>
 	</div>


### PR DESCRIPTION
Branch off of #61, with some changes:

* [x] console clears on rebuild (which means 'announcements' are no longer necessary)
* [x] toggle behaviour (click on the panel header) now shared between Result and JS Output tabs, resulting in more consistent UI
* [x] change font-family of JSONNode components to match other monospace type (might need to do this in svelte-json-tree, by exposing another CSS custom prop)
* [x] handle uncloneable items somehow
* [x] dedupe logs, the way Chrome devtools does