### PR TITLE
fix: no background for info message

### DIFF
--- a/src/Message.svelte
+++ b/src/Message.svelte
@@ -73,6 +73,10 @@
 	.warning {
 		background-color: #e47e0a;
 	}
+
+	.info {
+		background-color: var(--second);
+	}
 </style>
 
 <div in:slide={{delay: 150, duration: 100}} out:slide={{duration: 100}} class="message {kind}" class:truncate>


### PR DESCRIPTION
add a background color

<img width="1280" alt="Screenshot 2019-11-17 at 12 28 06 PM" src="https://user-images.githubusercontent.com/2338632/69003099-3bd6b700-0937-11ea-93d0-1f76380e85b8.png">
