### PR TITLE
Use svelte-inspect for console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,6 +1083,11 @@
       "integrity": "sha512-7gMPjARR9D797MSVaiUkILVfqDaDLKRQAPTGK5kktSmrPWE0iuHRTKIdhpMOa/MSQBM94NMUv8owR4LXrhrgfQ==",
       "dev": true
     },
+    "svelte-inspect": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/svelte-inspect/-/svelte-inspect-0.1.2.tgz",
+      "integrity": "sha512-7+xHhydg179lGEiIjwXt73YSDDNOs1/K5DMFvET9QUm+miMJLk6zaef8RPQewNHQqzSl2YoVMIEZcLJBy4iZ+Q=="
+    },
     "svelte-json-tree": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/svelte-json-tree/-/svelte-json-tree-0.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1088,11 +1088,6 @@
       "resolved": "https://registry.npmjs.org/svelte-inspect/-/svelte-inspect-0.1.2.tgz",
       "integrity": "sha512-7+xHhydg179lGEiIjwXt73YSDDNOs1/K5DMFvET9QUm+miMJLk6zaef8RPQewNHQqzSl2YoVMIEZcLJBy4iZ+Q=="
     },
-    "svelte-json-tree": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/svelte-json-tree/-/svelte-json-tree-0.0.5.tgz",
-      "integrity": "sha512-kTcOVlsldI2neszYNQAfFCt+u62OWWAZgpeoW9RN3hjtJCWI5bkVj0gtljZWUlyEWTfgpmag5L5AHDKg8w8ZmQ=="
-    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "codemirror": "^5.49.2",
     "estree-walker": "^0.9.0",
     "sourcemap-codec": "^1.4.6",
-    "svelte-json-tree": "0.0.5",
+    "svelte-inspect": "^0.1.2",
     "yootils": "0.0.16"
   }
 }

--- a/src/Output/Console.svelte
+++ b/src/Output/Console.svelte
@@ -1,5 +1,5 @@
 <script>
-	import JSONNode from 'svelte-json-tree';
+	import Inspect from 'svelte-inspect';
 
 	export let logs;
 </script>
@@ -17,7 +17,7 @@
 				<span class="info error">Message could not be cloned. Open devtools to see it</span>
 			{:else}
 				{#each log.args as arg}
-					<JSONNode value={arg} />
+					<Inspect.Value value={arg} />
 				{/each}
 			{/if}
 		</div>


### PR DESCRIPTION
Great idea to add a console to the REPL!

I created a package `svelte-inspect` months ago, which is rather similar to `svelte-json-tree` but more fully featured. It has really good keyboard support, formatting for more types, and is more elaborate in general.

It does not yet support the collapsed "summary" formatting that `svelte-json-tree` does. If that is a dealbreaker, we might want to stick with `svelte-json-tree`, otherwise I think this should be an improvement.