### PR TITLE
feat: bundle sizes tab (bundled+minified+gzipped)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 const dev = process.env.ROLLUP_WATCH;
 
 // bundle workers
-export default ['compiler', 'bundler'].map(x => ({
+export default ['compiler', 'bundler', 'sizes'].map(x => ({
 	input: `src/workers/${x}/index.js`,
 	output: {
 		file: `workers/${x}.js`,

--- a/src/Output/BundleSizes.svelte
+++ b/src/Output/BundleSizes.svelte
@@ -1,0 +1,92 @@
+<script>
+	export let sources;
+	export let compiled;
+	export let minified;
+	export let gzipped;
+
+	$: sourcesSize = normalize(
+		sources.reduce((total, bytes) => total + bytes, 0)
+	);
+	$: compiledSize = normalize(compiled);
+	$: minifiedSize = normalize(minified);
+	$: gzippedSize = normalize(gzipped);
+
+	function normalize(value) {
+		if (value === 0) {
+			return "n/a";
+		}
+		// we are using KiB here displayed the Microsoft Way KB
+		return value > 1024 ? `${(value / 1024).toFixed(2)} KB` : `${value} B`;
+	}
+</script>
+
+<style>
+	.sizes {
+		display: flex;
+		flex-direction: column;
+		font-family: var(--font-mono);
+		font-size: 13px;
+		line-height: 1.8;
+		height: 100%;
+		padding: 1rem;
+		justify-content: space-between;
+	}
+
+	span {
+		margin-left: 0.5rem;
+		color: #999;
+	}
+
+	.info {
+    	font-family: var(--font);
+    	margin-top: 1rem;
+    	background-color: var(--back-light);
+    	color: #999;
+    	padding: 1rem;
+    	border-radius: 4px;
+  	}
+
+	.info mark {
+    	background-color: inherit;
+	}
+</style>
+
+<div class="sizes">
+	<div>
+    	<div>
+      		Sources:
+      		<span>{sourcesSize}</span>
+    	</div>
+    	<div>
+			Compiled:
+      		<span>{compiledSize}</span>
+    	</div>
+    	<div>
+			Minified:
+			<span>{minifiedSize}</span>
+		</div>
+		<div>
+      		Gzipped:
+      		<span>{gzippedSize}</span>
+    	</div>
+	</div>
+
+	<div class="info">
+    	<mark>Sources</mark>
+    	correspond to the combined size of all source files. It does not take into
+    	account external imports.
+    	<br />
+    	<mark>Compiled</mark>
+    	correspond to the generated bundle size (external imports included).
+    	<br />
+    	<mark>Minified</mark>
+    	code is generated using
+    	<a href="https://terser.org" target="_blank">Terser</a>
+    	on the Compiled code.
+    	<br />
+    	<mark>Gzipped</mark>
+    	code is generated using
+    	<a href="http://nodeca.github.io/pako/" target="_blank">Pako</a>
+    	on the Minified code with a default level compression of 6.
+  	</div>
+</div>

--- a/src/Output/index.svelte
+++ b/src/Output/index.svelte
@@ -5,10 +5,11 @@
 	import PaneWithPanel from './PaneWithPanel.svelte';
 	import CompilerOptions from './CompilerOptions.svelte';
 	import Compiler from './Compiler.js';
+	import BundleSizes from './BundleSizes.svelte';
 	import CodeMirror from '../CodeMirror.svelte';
 	import { is_browser } from '../env.js';
 
-	const { register_output } = getContext('REPL');
+	const { bundleSizes, register_output } = getContext('REPL');
 
 	export let svelteUrl;
 	export let workersUrl;
@@ -120,6 +121,11 @@
 		class:active="{view === 'css'}"
 		on:click="{() => view = 'css'}"
 	>CSS output</button>
+
+	<button
+    	class:active="{view === 'sizes'}"
+    	on:click="{() => (view = 'sizes')}"
+	>Bundle sizes</button>
 </div>
 
 <!-- component viewer -->
@@ -170,3 +176,9 @@
 		readonly
 	/>
 </div>
+
+<!-- bundle sizes -->
+<div class="tab-content" class:visible={view === 'sizes'}>
+	<BundleSizes {...$bundleSizes} />
+</div>
+

--- a/src/Sizes.js
+++ b/src/Sizes.js
@@ -1,0 +1,34 @@
+let id = 1;
+
+export const defaultSizes = {sources: [0], compiled: 0, minified: 0, gzipped: 0};
+
+export default class Sizes {
+
+	constructor(workersUrl, packagesUrl) {
+		this.worker = new Worker(`${workersUrl}/sizes.js`)
+		this.worker.postMessage({ type: 'init', packagesUrl });
+		
+		this.handlers = new Map();
+
+		this.worker.addEventListener('message', event => {
+			const handler = this.handlers.get(event.data.id);
+
+			if (handler) { // if no handler, was meant for a different REPL
+				handler(event.data.sizes);
+				this.handlers.delete(event.data.id);
+			}
+		});
+	}
+
+	getSizes(compiled, components = []) {
+		return new Promise(fulfil => {
+			const uid = id++;
+			this.handlers.set(uid, fulfil);
+			this.worker.postMessage({ id: uid, compiled, components });
+		});
+	}
+
+	destroy() {
+		this.worker.terminate();
+	}
+}

--- a/src/workers/sizes/index.js
+++ b/src/workers/sizes/index.js
@@ -1,0 +1,54 @@
+let fulfil_ready;
+
+const ready = new Promise(f => {
+	fulfil_ready = f;
+});
+
+function getBytesLength(source) {
+	// TODO: Maybe we could use new Blob() instead ?
+	return new TextEncoder().encode(source).length;
+}
+
+let packagesUrl;
+
+self.addEventListener('message', async event => {
+	const { id, type = 'sizes', compiled, components } = event.data;
+	switch (type) {
+		case 'init':
+			packagesUrl = event.data.packagesUrl;
+			importScripts(`${packagesUrl}/terser@4.6.3/dist/bundle.min.js`)
+			importScripts(`${packagesUrl}/pako@1.0.11/dist/pako_deflate.min.js`)
+			fulfil_ready();
+			break;
+	
+		case 'sizes':
+			await ready;
+			postMessage({
+				id,
+				sizes: getSizes(compiled, components, { gzipLevel: 6 })
+			});
+			break;
+	}
+});
+
+
+function getSizes(compiledCode, components, options) {
+	let minified = 0;
+	let gzipped = 0;
+
+	const sources = components.map(({ source }) => getBytesLength(source));
+	const compiled = getBytesLength(compiledCode);
+
+	const terser = Terser.minify(compiledCode);
+	if (!terser.error) {
+		minified = getBytesLength(terser.code);
+		gzipped = getBytesLength(pako.gzip(terser.code, {level: options.gzipLevel, to: 'string'}));
+	}
+	
+	return {
+			sources,
+			compiled,
+			minified,
+			gzipped
+		}
+}


### PR DESCRIPTION
Introducing a new tab in the Output section regarding bundle sizes.

![image](https://user-images.githubusercontent.com/583204/73941197-141b3d80-48ed-11ea-9df3-9c39dd1535ae.png)

The PR introduces a new Worker `sizes.js` in charge of computing different various sizes which are all detailed using KB (aka [Kibibytes](https://en.wikipedia.org/wiki/Kibibyte))
The worker is then used via a Class `Sizes.js`. The entire computation is started by listenning the `$bundle` store, and generate the corresponding sizes:
- Sources: aggregate all source files
- Compiled: size of the generated bundle
- Minified: using Terser (imported in the worker from unpkg) on the compiled code.
- Gzipped: using Pako (imported in the worker from unpkg) on the minified code.

These sizes are then stored into a new store `bundleSizes` that I added to the REPL Context.

Finally `BundleSizes.svelte` listen to this `bundleSizes` stores and display everything.

All bytes sizes are computed using `TextEncoder` class to make sure we consider all utf things properly.

---

To be honest I didn't  take the time to actually validates the number in an empiric way. They seemed right in the first place.
I could perform this check if needed.

Closes #74 