### PR TITLE
dont pass name options to bundler

### DIFF
--- a/src/workers/bundler/index.js
+++ b/src/workers/bundler/index.js
@@ -185,7 +185,6 @@ async function get_bundle(uid, mode, cache, lookup) {
 					generate: mode,
 					format: 'esm',
 					dev: true,
-					name,
 					filename: name + '.svelte'
 				}, has_loopGuardTimeout_feature() && {
 					loopGuardTimeout: 100


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-repl/issues/45

to prevent unhelpful warnings about capitalising `options.name`