### PR TITLE
fix: remove trailing slash

### DIFF
--- a/src/workers/bundler/index.js
+++ b/src/workers/bundler/index.js
@@ -122,6 +122,9 @@ async function get_bundle(uid, mode, cache, lookup) {
 			// importing from another file in REPL
 			if (importee in lookup) return importee;
 
+			// remove trailing slash
+			if (importee.endsWith('/')) importee = importee.slice(0, -1);
+
 			// importing from a URL
 			if (importee.startsWith('http:') || importee.startsWith('https:')) return importee;
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-repl/issues/91

Fix unable to resolve import request that ends with a trailing slash, eg:

```js
import foo from './src/utils/
```

by removing the trailing slash in the resolver