### PR TITLE
fix wrong array contents

### DIFF
--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -75,14 +75,14 @@
 			['clear', 'log', 'info', 'dir', 'warn', 'error'].forEach((level) => {
 				const original = console[level];
 				console[level] = (...args) => {
+					const stringifiedArgs = JSON.stringify(args);
 					if (
 						previous.level === level &&
-						previous.args.length === args.length &&
-						previous.args.every((a, i) => a === args[i])
+						previous.args === stringifiedArgs
 					) {
 						parent.postMessage({ action: 'console', level, duplicate: true }, '*');
 					} else {
-						previous = { level, args };
+						previous = { level, args: stringifiedArgs };
 
 						try {
 							parent.postMessage({ action: 'console', level, args }, '*');

--- a/src/Output/srcdoc/index.html
+++ b/src/Output/srcdoc/index.html
@@ -75,9 +75,10 @@
 			['clear', 'log', 'info', 'dir', 'warn', 'error'].forEach((level) => {
 				const original = console[level];
 				console[level] = (...args) => {
-					const stringifiedArgs = JSON.stringify(args);
+					const stringifiedArgs = stringify(args);
 					if (
 						previous.level === level &&
+						previous.args &&
 						previous.args === stringifiedArgs
 					) {
 						parent.postMessage({ action: 'console', level, duplicate: true }, '*');
@@ -94,6 +95,14 @@
 					original(...args);
 				}
 			})
+
+			function stringify(args) {
+				try {
+					return JSON.stringify(args);
+				} catch (error) {
+					return null;
+				}
+			}
 		</script>
 	</head>
 	<body></body>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-repl/issues/80

use `JSON.stringify` to make sure that previous args content is exactly the same.

<img width="1280" alt="Screenshot 2020-04-10 at 10 29 09 AM" src="https://user-images.githubusercontent.com/2338632/78956889-5859d280-7b16-11ea-9e87-3d72b56590c2.png">
