### PR TITLE
manage editor undo history

### DIFF
--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -72,7 +72,7 @@
 	}
 
 	export function clearHistory() {
-		editor.clearHistory();
+		if (editor) editor.clearHistory();
 	}
 
 	const modes = {
@@ -135,18 +135,16 @@
 	}
 
 	onMount(() => {
-		if (_CodeMirror) {
-			CodeMirror = _CodeMirror;
-			createEditor(mode || 'svelte').then(() => {
-				if (editor) editor.setValue(code || '');
-			});
-		} else {
-			codemirror_promise.then(async mod => {
+		(async () => {
+			if (!_CodeMirror) {
+				let mod = await codemirror_promise;
 				CodeMirror = mod.default;
-				await createEditor(mode || 'svelte');
-				if (editor) editor.setValue(code || '');
-			});
-		}
+			} else {
+				CodeMirror = _CodeMirror;
+			}
+			await createEditor(mode || 'svelte');
+			if (editor) editor.setValue(code || '');
+		})();
 
 		return () => {
 			destroyed = true;

--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -63,6 +63,18 @@
 		editor.focus();
 	}
 
+	export function getHistory() {
+		return editor.getHistory();
+	}
+
+	export function setHistory(history) {
+		editor.setHistory(history);
+	}
+
+	export function clearHistory() {
+		editor.clearHistory();
+	}
+
 	const modes = {
 		js: {
 			name: 'javascript',

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -19,6 +19,8 @@
 	export let injectedJS = '';
 	export let injectedCSS = '';
 
+	const historyMap = new Map();
+
 	export function toJSON() {
 		return {
 			imports: $bundle.imports,
@@ -155,8 +157,14 @@
 	});
 
 	function handle_select(component) {
+		historyMap.set($selected.name, module_editor.getHistory());
 		selected.set(component);
 		module_editor.set(component.source, component.type);
+		if (historyMap.has($selected.name)) {
+			module_editor.setHistory(historyMap.get($selected.name));
+		} else {
+			module_editor.clearHistory();
+		}
 		output.set($selected, $compile_options);
 	}
 

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -40,6 +40,9 @@
 		injectedCSS = data.css || '';
 		module_editor.set($selected.source, $selected.type);
 		output.set($selected, $compile_options);
+
+		historyMap.clear();
+		module_editor.clearHistory();
 	}
 
 	export function update(data) {
@@ -58,6 +61,8 @@
 		} else {
 			module_editor.set(matched_component.source, matched_component.type);
 			output.set(matched_component, $compile_options);
+
+			module_editor.clearHistory();
 		}
 	}
 
@@ -157,15 +162,19 @@
 	});
 
 	function handle_select(component) {
-		historyMap.set($selected.name, module_editor.getHistory());
+		historyMap.set(get_component_name($selected), module_editor.getHistory());
 		selected.set(component);
 		module_editor.set(component.source, component.type);
-		if (historyMap.has($selected.name)) {
-			module_editor.setHistory(historyMap.get($selected.name));
+		if (historyMap.has(get_component_name($selected))) {
+			module_editor.setHistory(historyMap.get(get_component_name($selected)));
 		} else {
 			module_editor.clearHistory();
 		}
 		output.set($selected, $compile_options);
+	}
+
+	function get_component_name(component) {
+		return `${component.name}.${component.type}`
 	}
 
 	let input;

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -38,7 +38,7 @@
 		await output_ready;
 
 		injectedCSS = data.css || '';
-		module_editor.set($selected.source, $selected.type);
+		await module_editor.set($selected.source, $selected.type);
 		output.set($selected, $compile_options);
 
 		historyMap.clear();


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-repl/issues/3

- keep track and preserve undo history across tabs


![undo-buffer](https://user-images.githubusercontent.com/2338632/79248388-5ee9a080-7eae-11ea-9ba3-b1ea9c49d8d6.gif)
