### PR TITLE
define process.env.NODE_ENV in bundler

### DIFF
--- a/src/workers/bundler/index.js
+++ b/src/workers/bundler/index.js
@@ -2,6 +2,7 @@ import * as rollup from 'rollup/dist/es/rollup.browser.js';
 import commonjs from './plugins/commonjs.js';
 import glsl from './plugins/glsl.js';
 import json from './plugins/json.js';
+import replace from './plugins/replace.js';
 
 self.window = self; // egregious hack to get magic-string to work in a worker
 
@@ -217,7 +218,10 @@ async function get_bundle(uid, mode, cache, lookup) {
 				repl_plugin,
 				commonjs,
 				json,
-				glsl
+				glsl,
+				replace({
+					'process.env.NODE_ENV': JSON.stringify('production')
+				})
 			],
 			inlineDynamicImports: true,
 			onwarn(warning) {
@@ -229,6 +233,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 
 		return { bundle, imports: Array.from(imports), cache: new_cache, error: null, warnings, all_warnings };
 	} catch (error) {
+		console.log(error);
 		return { error, imports: null, bundle: null, cache: new_cache, warnings, all_warnings };
 	}
 }

--- a/src/workers/bundler/plugins/replace.js
+++ b/src/workers/bundler/plugins/replace.js
@@ -1,0 +1,58 @@
+function escape(str) {
+  return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
+}
+
+function ensureFunction(functionOrValue) {
+  if (typeof functionOrValue === 'function') {
+    return functionOrValue;
+  }
+  return function () {
+    return functionOrValue;
+  };
+}
+
+function longest(a, b) {
+  return b.length - a.length;
+}
+
+function mapToFunctions(object) {
+  return Object.keys(object).reduce(function (functions, key) {
+    functions[key] = ensureFunction(object[key]);
+    return functions;
+  }, {});
+}
+
+function replace(options) {
+  const functionValues = mapToFunctions(options);
+  const keys = Object.keys(functionValues).sort(longest).map(escape);
+
+  const pattern = new RegExp('\\b(' + keys.join('|') + ')\\b', 'g');
+
+  return {
+    name: 'replace',
+
+    transform: function transform(code, id) {
+      let hasReplacements = false;
+      let match;
+      let start;
+      let end;
+      let replacement;
+
+      code = code.replace(pattern, (_, key) => {
+        hasReplacements = true;
+        return String(functionValues[key](id));
+      });
+
+      if (!hasReplacements) {
+        return null;
+      }
+
+      return {
+        code,
+        map: null,
+      };
+    },
+  };
+}
+
+export default replace;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-repl/issues/105

- added replace plugin to the bundler
- copied a slim down version of `rollup-replace-plugin` because the original one provides `include` and `exclude` option that uses `path` and `utils` to match files, however these node apis are not available in the browser.