### PR TITLE
Block translation in code

### DIFF
--- a/src/Input/ModuleEditor.svelte
+++ b/src/Input/ModuleEditor.svelte
@@ -45,7 +45,7 @@
 </style>
 
 <div class="editor-wrapper">
-	<div class="editor">
+	<div class="editor notranslate" translate="no">
 		<CodeMirror
 			bind:this={editor}
 			{errorLoc}


### PR DESCRIPTION
When using browser translation, the entire editor is also translated, making it difficult to use.

<img width="1440" alt="Captura de Tela 2020-05-12 às 22 50 36" src="https://user-images.githubusercontent.com/16120343/81762492-1fa97200-94a3-11ea-867a-bb1cb27225c9.png">

I believe that would solve this issue https://github.com/sveltejs/svelte/issues/2934.


