### PR TITLE
add themes to Repl

### DIFF
--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -24,6 +24,7 @@
 	export let flex = false;
 	export let lineNumbers = true;
 	export let tab = true;
+  export let theme = 'default';
 
 	let w;
 	let h;
@@ -184,7 +185,8 @@
 				}
 			},
 			foldGutter: true,
-			gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter']
+			gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+      theme: theme,
 		};
 
 		if (!tab) {

--- a/src/Input/ModuleEditor.svelte
+++ b/src/Input/ModuleEditor.svelte
@@ -6,6 +6,7 @@
 	const { bundle, selected, handle_change, register_module_editor } = getContext('REPL');
 
 	export let errorLoc;
+	export let theme;
 
 	let editor;
 	onMount(() => {
@@ -50,6 +51,7 @@
 			bind:this={editor}
 			{errorLoc}
 			on:change={handle_change}
+			{theme}
 		/>
 	</div>
 

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -18,6 +18,8 @@
 	export let fixedPos = 50;
 	export let injectedJS = '';
 	export let injectedCSS = '';
+	export let themeUrl;
+	export let theme;
 
 	const historyMap = new Map();
 
@@ -225,6 +227,13 @@
 	}
 </style>
 
+<svelte:head>
+<!-- TODO is this the best way to access a themes css? -->
+	{#if themeUrl}
+	<link rel="stylesheet" href={themeUrl} />
+	{/if}
+</svelte:head>
+
 <div class="container" class:orientation>
 	<SplitPane
 		type="{orientation === 'rows' ? 'vertical' : 'horizontal'}"
@@ -233,7 +242,7 @@
 	>
 		<section slot=a>
 			<ComponentSelector {handle_select}/>
-			<ModuleEditor bind:this={input} errorLoc="{sourceErrorLoc || runtimeErrorLoc}"/>
+			<ModuleEditor bind:this={input} errorLoc="{sourceErrorLoc || runtimeErrorLoc}" {theme}/>
 		</section>
 
 		<section slot=b style='height: 100%;'>


### PR DESCRIPTION
This will allow users to create/use themes for the REPL. `Repl.svelte` now accepts two props; `themeUrl` and `theme`. If `themeUrl` is passed, the url is added as a link in the header.  `theme` is the name of the theme CodeMirror will add to the class of each of the CodeMirror components. It defaults to `default`. 

 An  example would be 
```html
<Repl 
  workersUrl="workers"   
  svelteUrl="https://unpkg.com/svelte@latest"
  rollupUrl="https://unpkg.com/rollup@1/dist/rollup.browser.js"    
  relaxed=true
  themeUrl= "https://raw.githubusercontent.com/codemirror/CodeMirror/master/theme/cobalt.css"
  theme="cobalt"
/>
```

or if using `ReplWidget.svelte` from the `Svelte` site...
```html
<Repl
  bind:this={repl}
  workersUrl="workers"
  fixed={mobile}
  {svelteUrl}
  {rollupUrl}
  embedded
  relaxed
  themeUrl= "https://raw.githubusercontent.com/codemirror/CodeMirror/master/theme/cobalt.css"
  theme="cobalt"
/>
```