### PR TITLE
Execute bundle code after clear the body

### DIFF
--- a/src/Output/Viewer.svelte
+++ b/src/Output/Viewer.svelte
@@ -98,8 +98,6 @@
 
 				const styles = document.querySelectorAll('style[id^=svelte-]');
 
-				${$bundle.dom.code}
-
 				let i = styles.length;
 				while (i--) styles[i].parentNode.removeChild(styles[i]);
 
@@ -114,6 +112,8 @@
 				document.body.innerHTML = '';
 				window.location.hash = '';
 				window._svelteTransitionManager = null;
+
+				${$bundle.dom.code}
 
 				window.component = new SvelteComponent.default({
 					target: document.body


### PR DESCRIPTION
# Bug

REPL clear the body after bundle code execution.

## Example

See [REPL](https://svelte.dev/repl/2fab703ff1f4470da0b523679c361fe7)

### Expected result

- Clear the body
- Append a node with text `before` to the body (index.js)
- Creating a component (App.svelte)
- Append a node with text `after` to the body (App.svelte)
- ...

```html
<body>
  <p>before</p>
  <p>after</p>
  <h1>:(</h1>
</body>
```

### Actual result

- Append a node with text  `before` to the body  (index.js)
- **Clear the body**
- Creating a component (App.svelte)
- Append a node with text `after` to the body (App.svelte)
- ...

```html
<body>
  <p>after</p>
  <h1>:(</h1>
</body>
```
