### PR TITLE
add selectComponent option to REPL

### DIFF
--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -30,7 +30,18 @@
 
 	export async function set(data) {
 		components.set(data.components);
-		selected.set(data.components[0]);
+		
+		let selectedIndex = 0;
+		if (data.selectedComponent) {
+			const name = data.selectedComponent.split('.')[0];
+			const type = data.selectedComponent.split('.')[1];
+			data.components.forEach((v, i) => {
+				if (v.name === name && v.type === type) {
+					selectedIndex = i;
+				}
+			});
+		}
+		selected.set(data.components[selectedIndex]);
 
 		rebundle();
 


### PR DESCRIPTION
Currently, `App.svelte` is the component that is selected when the REPL is created. It would be nice for examples and tutorials for the component that is the focus of the example to be initially selected without user interaction. 

This will allow an object key called `selectedComponent` to be passed with a string to indicate which component to initially select when `repl.set()` is called. 

By putting the `selectedComponent` in the metadata of `text.md` in the tutorials, the data could be extracted pretty easily and used when `repl.set()` is called. Some of the tutorials would become more intuitive, since it's a component or store, not `App.svelte`, that changes when `Show Me` is clicked. 

Below is an example of how it works.

```html
<script>
  import { onMount } from 'svelte';
  import Repl from './REPL/Repl.svelte';
  let repl;

  const appA = {
    components: [
      {
        name: 'App',
        type: 'svelte',
        source: `<script>
  import SelectMe from './SelectMe.svelte'
<\/script>

<h3>App.svelte: "Hey, I always go first!!!"</h3>
<SelectMe />`,
      },
      {
        name: 'SelectMe',
        type: 'svelte',
        source: `<h3 style="margin: 1em">SelectMe.svelte: "Not today, buddy!!!"</h3>`,
      },
    ],
    selectedComponent: 'SelectMe.svelte',
  };

  onMount(function mount() {
    if (repl) {
      repl.set(appA);
    } else {
      setTimeout(mount, 1);
    }
  });
</script>

<Repl bind:this={repl} workersUrl="workers" />
```