### PR TITLE
Completes "TODO select the line/column in question" in the REPL navigate function

### DIFF
--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -76,8 +76,12 @@
 	}
 	
 	export function setCursor(pos, ch, options) {
-  	editor.setCursor(pos, ch, options);
-  }
+  		editor.setCursor(pos, ch, options);
+  	}
+	
+	export function setSelection(anchor, head, options) {
+		editor.setSelection(anchor, head, options);
+	}
 
 	const modes = {
 		js: {

--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -74,6 +74,10 @@
 	export function clearHistory() {
 		if (editor) editor.clearHistory();
 	}
+	
+	export function setCursor(pos, ch, options) {
+  	editor.setCursor(pos, ch, options);
+  }
 
 	const modes = {
 		js: {

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -18,6 +18,7 @@
 	export let fixedPos = 50;
 	export let injectedJS = '';
 	export let injectedCSS = '';
+	export let errorSelect = 'selection';
 
 	const historyMap = new Map();
 
@@ -120,7 +121,27 @@
 			const component = $components.find(c => c.name === name && c.type === type);
 			handle_select(component);
 
-			// TODO select the line/column in question
+			setTimeout(() => {
+				module_editor.focus();
+				if (errorSelect === 'cursor') {
+						module_editor.setCursor({
+							line: item.start.line - 1,
+							ch: item.start.column,
+						});
+					} else if (errorSelect === 'selection') {
+						module_editor.setSelection(
+							{
+								line: item.start.line - 1,
+								ch: item.start.column,
+							},
+							{
+								line: item.end.line - 1,
+								ch: item.end.column,
+							}
+						);
+					}
+				}, 0);
+			},
 		},
 
 		handle_change: event => {


### PR DESCRIPTION
When a warning is displayed and clicked, will by default select the start and end of the code causing the warning. A prop called `errorSelect` can be passed to the `REPL` component with a value of `'cursor'` to change the behavior so the cursor moves to the start of the code causing the warning, but won't select any of the text.