### PR TITLE
upgrade rollup to 2.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,9 +866,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.10",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.10.tgz",
-      "integrity": "sha512-dUnjCWOA0h9qNX6qtcHidyatz8FAFZxVxt1dbcGtKdlJkpSxGK3G9+DLCYvtZr9v94D129ij9zUhG+xbRoqepw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.29.0.tgz",
+      "integrity": "sha512-gtU0sjxMpsVlpuAf4QXienPmUAhd6Kc7owQ4f5lypoxBW18fw2UNYZ4NssLGsri6WhUZkE/Ts3EMRebN+gNLiQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "eslint": "^6.6.0",
     "eslint-plugin-svelte3": "^2.7.3",
-    "rollup": "^2.26.10",
+    "rollup": "^2.29.0",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^5.3.0",


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/5514

rollup 2.29.0 upgrades acorn to 8.0.3, which supports the logical assignment operator