### PR TITLE
fix: only return local importee if importer is also local

### DIFF
--- a/src/workers/bundler/index.js
+++ b/src/workers/bundler/index.js
@@ -120,7 +120,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 			}
 
 			// importing from another file in REPL
-			if (importee in lookup) return importee;
+			if (importee in lookup && (!importer || importer in lookup)) return importee;
 			if ((importee + '.js') in lookup) return importee + '.js';
 			if ((importee + '.json') in lookup) return importee + '.json';
 


### PR DESCRIPTION
We should only return the importee from the lookup if the importer is also in the lookup (both are local). The falsey check is there for when the importer is undefined (which is true when resolving the entrypoint).

Closes #144