### PR TITLE
Adds warning when files have unsaved changes

### DIFF
--- a/src/Input/ComponentSelector.svelte
+++ b/src/Input/ComponentSelector.svelte
@@ -1,9 +1,10 @@
 <script>
-	import { getContext } from 'svelte';
+	import { getContext, createEventDispatcher } from 'svelte';
 
 	export let handle_select;
 
 	const { components, selected, request_focus, rebundle } = getContext('REPL');
+	const dispatch = createEventDispatcher()
 
 	let editing = null;
 
@@ -54,6 +55,7 @@
 
 			if (~index) {
 				components.set($components.slice(0, index).concat($components.slice(index + 1)));
+				dispatch('remove', {components: $components})
 			} else {
 				console.error(`Could not find component! That's... odd`);
 			}
@@ -74,7 +76,8 @@
 		const component = {
 			name: uid++ ? `Component${uid}` : 'Component1',
 			type: 'svelte',
-			source: ''
+			source: '',
+			modified: true
 		};
 
 		editing = component;
@@ -86,6 +89,8 @@
 
 		components.update(components => components.concat(component));
 		handle_select(component);
+
+		dispatch('add', {components: $components})
 	}
 
 	function isComponentNameUsed(editing) {
@@ -288,7 +293,7 @@
 					<i class="drag-handle"></i>
 					{#if component.name === 'App' && component !== editing}
 						<div class="uneditable">
-							App.svelte
+							App.svelte{#if component.modified}*{/if}
 						</div>
 					{:else}
 						{#if component === editing}
@@ -310,7 +315,7 @@
 								title="edit component name"
 								on:click="{() => editTab(component)}"
 							>
-								{component.name}.{component.type}
+								{component.name}.{component.type}{#if component.modified}*{/if}
 							</div>
 
 							<span class="remove" on:click="{() => remove(component)}">

--- a/src/Input/ComponentSelector.svelte
+++ b/src/Input/ComponentSelector.svelte
@@ -4,7 +4,7 @@
 	export let handle_select;
 
 	const { components, selected, request_focus, rebundle } = getContext('REPL');
-	const dispatch = createEventDispatcher()
+	const dispatch = createEventDispatcher();
 
 	let editing = null;
 
@@ -55,7 +55,7 @@
 
 			if (~index) {
 				components.set($components.slice(0, index).concat($components.slice(index + 1)));
-				dispatch('remove', {components: $components})
+				dispatch('remove', { components: $components });
 			} else {
 				console.error(`Could not find component! That's... odd`);
 			}
@@ -90,7 +90,7 @@
 		components.update(components => components.concat(component));
 		handle_select(component);
 
-		dispatch('add', {components: $components})
+		dispatch('add', { components: $components });
 	}
 
 	function isComponentNameUsed(editing) {

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -48,9 +48,9 @@
 	export function markSaved() {
 		components.update(components =>
 			components.map(c => {
-				c.modified = false
-				return c
-			})
+				c.modified = false;
+				return c;
+			});
 		)
 		selected.update(c => c);
 	}
@@ -142,16 +142,17 @@
 				// derived from `components` and `index`
 				if (component.source != event.detail.value) {
 					component.source = event.detail.value;
-					component.modified = true
+					component.modified = true;
 				}
 				return component;
 			});
 
 			components.update(component => {
-				if (component.name === $selected.name)
-					return $selected
+				if (component.name === $selected.name) {
+					return $selected;
+				}
 
-				return component
+				return component;
 			});
 
 			// recompile selected component
@@ -197,8 +198,8 @@
 
 	function beforeUnload(event) {
 		if ($components.find(component => component.modified)) {
-			event.preventDefault()
-			event.returnValue = ''
+			event.preventDefault();
+			event.returnValue = '';
 		}
 	}
 

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -45,6 +45,16 @@
 		module_editor.clearHistory();
 	}
 
+	export function markSaved() {
+		components.update(components =>
+			components.map(c => {
+				c.modified = false
+				return c
+			})
+		)
+		selected.update(c => c);
+	}
+
 	export function update(data) {
 		const { name, type } = $selected || {};
 
@@ -130,11 +140,19 @@
 				// if a) components had unique IDs, b) we tracked selected
 				// *index* rather than component, and c) `selected` was
 				// derived from `components` and `index`
-				component.source = event.detail.value;
+				if (component.source != event.detail.value) {
+					component.source = event.detail.value;
+					component.modified = true
+				}
 				return component;
 			});
 
-			components.update(c => c);
+			components.update(component => {
+				if (component.name === $selected.name)
+					return $selected
+
+				return component
+			});
 
 			// recompile selected component
 			output.update($selected, $compile_options);
@@ -175,6 +193,13 @@
 
 	function get_component_name(component) {
 		return `${component.name}.${component.type}`
+	}
+
+	function beforeUnload(event) {
+		if ($components.find(component => component.modified)) {
+			event.preventDefault()
+			event.returnValue = ''
+		}
 	}
 
 	let input;
@@ -225,6 +250,8 @@
 	}
 </style>
 
+<svelte:window on:beforeunload={beforeUnload}/>
+
 <div class="container" class:orientation>
 	<SplitPane
 		type="{orientation === 'rows' ? 'vertical' : 'horizontal'}"
@@ -232,7 +259,7 @@
 		{fixed}
 	>
 		<section slot=a>
-			<ComponentSelector {handle_select}/>
+			<ComponentSelector {handle_select} on:add on:remove/>
 			<ModuleEditor bind:this={input} errorLoc="{sourceErrorLoc || runtimeErrorLoc}"/>
 		</section>
 


### PR DESCRIPTION
Displays a warning when there are unsaved changes and the user attempts to navigate away.
Fixes #117 

Currently, if you have unsaved change and reload the tab or navigate away, you lose all your code.

What this PR does:

https://user-images.githubusercontent.com/4437/113047295-226e8d80-916f-11eb-991a-a170de292dd0.mp4

- fires events `add` & `remove` when a file is added or removed, so that parent components in `svelte/site` can track changes
- adds a `*` next to the name when file is unsaved
- exports a function `markSaved()` for use by parent components in `svelte/site`.
- handles `onbeforeunload` and checks if files are modified

It also adds changes to `svelte/site` which you can see here sveltejs/svelte#6153