### PR TITLE
a11y: remove tabindex and allow escaping codemirror

### DIFF
--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -172,7 +172,7 @@
 			readOnly: readonly,
 			autoCloseBrackets: true,
 			autoCloseTags: true,
-			extraKeys: {
+			extraKeys: CodeMirror.normalizeKeyMap({
 				'Enter': 'newlineAndIndentContinueMarkdownList',
 				'Ctrl-/': 'toggleComment',
 				'Cmd-/': 'toggleComment',
@@ -181,8 +181,10 @@
 				},
 				'Cmd-Q': function (cm) {
 					cm.foldCode(cm.getCursor());
-				}
-			},
+				},
+				// allow escaping the CodeMirror with Esc Tab
+				'Esc Tab': false
+			}),
 			foldGutter: true,
 			gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter']
 		};
@@ -287,9 +289,7 @@
 </style>
 
 <div class='codemirror-container' class:flex bind:offsetWidth={w} bind:offsetHeight={h}>
-	<!-- svelte-ignore a11y-positive-tabindex -->
 	<textarea
-		tabindex='2'
 		bind:this={refs.editor}
 		readonly
 		value={code}

--- a/src/Output/index.svelte
+++ b/src/Output/index.svelte
@@ -109,13 +109,12 @@
 		position: absolute;
 		width: 100%;
 		height: calc(100% - 42px) !important;
-		opacity: 0;
+		visibility: hidden;
 		pointer-events: none;
 	}
 
 	.tab-content.visible {
-		/* can't use visibility due to a weird painting bug in Chrome */
-		opacity: 1;
+		visibility: visible;
 		pointer-events: all;
 	}
 	iframe {


### PR DESCRIPTION
Fixes #163

This PR makes some accessibility improvements to the REPL:
- Remove the positive tabindex on the text area. This was causing the REPL to be the first thing focused on the page. This impacted the svelte.dev homepage, since a keyboard user would skip the initial page content and immediately enter the first REPL example when they pressed Tab on initial load (see also https://github.com/sveltejs/svelte/issues/6369). I didn't notice anything broken by removing the tabindex, but let me know if I missed anything.
- Allow escaping the CodeMirror by pressing Esc. If a keyboard-only user entered the REPL, they could not get out since pressing Tab triggered indentation. Now, if they hit Esc, the next press of Tab or Shift-Tab will use the default browser tabbing behavior. Otherwise, Tab will be used for indentation. CodeMirror 6 will have a [similar escape hatch](https://codemirror.net/6/examples/tab/). I wasn't sure how/if to document this, but it's there if people need it.
- Use `visibility: hidden` to hide the output JS and CSS panels. Otherwise, they were receiving focus even when their corresponding tab was not selected. This caused focus to be lost when navigating with the keyboard. There was a 2-year-old comment saying that `visibility` couldn't be used due to a Chrome bug, but I didn't notice any weird behavior after applying my change. Maybe that bug isn't an issue in the latest Chrome? Let me know if I should find another way to approach the problem.

I linked my local REPL with my local svelte.dev to test the changes and verified that keyboard navigation works as expected.