### PR TITLE
Vite/SvelteKit compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -676,9 +676,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "codemirror": "^5.49.2",
     "estree-walker": "^0.9.0",
-    "marked": "^0.8.2",
+    "marked": "^2.0.0",
     "sourcemap-codec": "^1.4.6",
     "svelte-json-tree": "0.0.5",
     "yootils": "0.0.16"

--- a/src/Output/index.svelte
+++ b/src/Output/index.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { getContext, onMount } from 'svelte';
-	import marked from 'marked';
+	import * as marked from 'marked';
 	import SplitPane from '../SplitPane.svelte';
 	import Viewer from './Viewer.svelte';
 	import PaneWithPanel from './PaneWithPanel.svelte';
@@ -34,7 +34,7 @@
 			}
 
 			if (selected.type === 'md') {
-				markdown = marked(selected.source);
+				markdown = marked.parse(selected.source);
 				return;
 			}
 
@@ -49,7 +49,7 @@
 			if (selected.type === 'js' || selected.type === 'json') return;
 
 			if (selected.type === 'md') {
-				markdown = marked(selected.source);
+				markdown = marked.parse(selected.source);
 				return;
 			}
 


### PR DESCRIPTION
`marked` is suboptimally packaged so we need this workaround (https://github.com/markedjs/marked/issues/2021). Upgrade the `marked` while we're at it