### PR TITLE
Upgrade to marked 3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "codemirror": "^5.49.2",
         "estree-walker": "^0.9.0",
-        "marked": "^3.0.0",
+        "marked": "3.0.5",
         "sourcemap-codec": "^1.4.6",
         "svelte-json-tree": "0.0.5",
         "yootils": "0.0.16"
@@ -852,9 +852,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.0.tgz",
-      "integrity": "sha512-IF2MYfFafPsLIhzLTu63secRBwOmIY+vwS+ei6qg8F+bTS+MxH6ONYRmuseGdZqF44qvoi3nP/rlpClBdgLbiQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.5.tgz",
+      "integrity": "sha512-6sXDj79pTjEiu9HfOH7LcqggjUtLHXEG3wxzhSI3zr0uwxIjyDy2rpRWDDLmIeWvUIHNkpalsIcW5JjPAVikaA==",
       "bin": {
         "marked": "bin/marked"
       },
@@ -2220,9 +2220,9 @@
       "dev": true
     },
     "marked": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.0.tgz",
-      "integrity": "sha512-IF2MYfFafPsLIhzLTu63secRBwOmIY+vwS+ei6qg8F+bTS+MxH6ONYRmuseGdZqF44qvoi3nP/rlpClBdgLbiQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.5.tgz",
+      "integrity": "sha512-6sXDj79pTjEiu9HfOH7LcqggjUtLHXEG3wxzhSI3zr0uwxIjyDy2rpRWDDLmIeWvUIHNkpalsIcW5JjPAVikaA=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "codemirror": "^5.49.2",
     "estree-walker": "^0.9.0",
-    "marked": "^3.0.0",
+    "marked": "3.0.5",
     "sourcemap-codec": "^1.4.6",
     "svelte-json-tree": "0.0.5",
     "yootils": "0.0.16"


### PR DESCRIPTION
svelte.dev on SvelteKit only works with 3.0.5 currently. I'll send some follow up PRs to marked to see if we can improve this