### PR TITLE
SvelteKit compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "codemirror": "^5.49.2",
         "estree-walker": "^0.9.0",
-        "marked": "^3.0.0",
+        "marked": "3.0.5",
         "sourcemap-codec": "^1.4.6",
         "svelte-json-tree": "0.0.5",
         "yootils": "0.0.16"
@@ -852,9 +852,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.0.tgz",
-      "integrity": "sha512-IF2MYfFafPsLIhzLTu63secRBwOmIY+vwS+ei6qg8F+bTS+MxH6ONYRmuseGdZqF44qvoi3nP/rlpClBdgLbiQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.5.tgz",
+      "integrity": "sha512-6sXDj79pTjEiu9HfOH7LcqggjUtLHXEG3wxzhSI3zr0uwxIjyDy2rpRWDDLmIeWvUIHNkpalsIcW5JjPAVikaA==",
       "bin": {
         "marked": "bin/marked"
       },
@@ -2220,9 +2220,9 @@
       "dev": true
     },
     "marked": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.0.tgz",
-      "integrity": "sha512-IF2MYfFafPsLIhzLTu63secRBwOmIY+vwS+ei6qg8F+bTS+MxH6ONYRmuseGdZqF44qvoi3nP/rlpClBdgLbiQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.5.tgz",
+      "integrity": "sha512-6sXDj79pTjEiu9HfOH7LcqggjUtLHXEG3wxzhSI3zr0uwxIjyDy2rpRWDDLmIeWvUIHNkpalsIcW5JjPAVikaA=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "codemirror": "^5.49.2",
     "estree-walker": "^0.9.0",
-    "marked": "^3.0.0",
+    "marked": "3.0.5",
     "sourcemap-codec": "^1.4.6",
     "svelte-json-tree": "0.0.5",
     "yootils": "0.0.16"

--- a/src/CodeMirror.svelte
+++ b/src/CodeMirror.svelte
@@ -1,19 +1,10 @@
 <script context="module">
-	import { is_browser } from './env.js';
-
 	let codemirror_promise;
 	let _CodeMirror;
-
-	if (is_browser) {
-		codemirror_promise = import('./codemirror.js');
-
-		codemirror_promise.then(mod => {
-			_CodeMirror = mod.default;
-		});
-	}
 </script>
 
 <script>
+	import './codemirror.css';
 	import { onMount, createEventDispatcher } from 'svelte';
 	import Message from './Message.svelte';
 
@@ -135,6 +126,9 @@
 	}
 
 	onMount(() => {
+		if (!codemirror_promise) {
+			codemirror_promise = import('./codemirror.js');
+		}
 		(async () => {
 			if (!_CodeMirror) {
 				let mod = await codemirror_promise;


### PR DESCRIPTION
This is the last big thing needed to migrate svelte.dev to SvelteKit (https://github.com/sveltejs/svelte/pull/6811)

I've sent https://github.com/markedjs/marked/pull/2227 which will allow us to unpin the `marked` version

CodeMirror 6 is in development and is ESM-based, but it appears you must build the packages manually and it's not on npm yet. When it's ready that should make it much easier to use with Vite.

This is perhaps an imperfect fix, but @Conduitry, @bluwy, and myself have all looked at this a bit any no one's come up with a better solution yet or even a way to reproduce the issue to report it in the Vite issue tracker. I think this is the most reasonable way to get unblocked for now and when there are new versions of the dependencies available we can update them here.