### PR TITLE
fix scroll when opening a new tab

### DIFF
--- a/src/Input/ComponentSelector.svelte
+++ b/src/Input/ComponentSelector.svelte
@@ -79,11 +79,6 @@
 
 		editing = component;
 
-		setTimeout(() => {
-			// TODO we can do this without IDs
-			document.getElementById(component.name).scrollIntoView(false);
-		});
-
 		components.update(components => components.concat(component));
 		handle_select(component);
 	}


### PR DESCRIPTION
fix: https://github.com/sveltejs/svelte/issues/6943

I thought the `scrollIntoView` was unnecessary but is this correct?
`scrollIntoView` is calling from `addNew` function.
`addNew` is calling from `dblclick` and `click` events.
I thought that in order for these events to fire, an element would need to be on a screen.
Therefore there would be no need to scroll.

This GIF was taken with updated code.
![svelte-6943-after](https://user-images.githubusercontent.com/19153718/142716098-6c73e8f7-4710-4608-a990-0aeab55dc507.gif)
